### PR TITLE
added tarball heading link, tar.gz and .zip from GitHub link

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -135,8 +135,9 @@
       <h2 id="source"><a href="#source">Source Tarballs</a></h2>
       <p>Link: <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/retroshare_0.6.0.RC2~8551_src.tgz/download">RetroShare-0.6.0-rc2.tar.gz</a> <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/checksums.txt.asc/download">checksums</a></p>
       
-      <p>Development Snapshots from Git: <a href="https://github.com/RetroShare/RetroShare/archive/master.tar.gz">.tar.gz</a> <a href="https://github.com/RetroShare/RetroShare/archive/master.zip">.zip</a></p>
-            
+      <p>Development Snapshots from GitHub: <a href="https://github.com/RetroShare/RetroShare/archive/master.tar.gz">.tar.gz</a> <a href="https://github.com/RetroShare/RetroShare/archive/master.zip">.zip</a></p>
+      <p>Mirror at GitLab: <a href="https://gitlab.com/RetroShare/RetroShare/repository/archive.tar.gz?ref=master">.tar.gz</a> <a href="https://gitlab.com/RetroShare/RetroShare/repository/archive.zip?ref=master">.zip</a> <a href="https://gitlab.com/RetroShare/RetroShare/repository/archive.tar.bz2?ref=master">.tar.bz2</a> <a href="https://gitlab.com/RetroShare/RetroShare/repository/archive.tar?ref=master">.tar</a></p>
+
     </div>
   </div>
 

--- a/downloads.html
+++ b/downloads.html
@@ -132,10 +132,11 @@
     <div class="tiny-2 columns"><img alt="Tar.gz logo" src="img/tgz-logo.svg"></div>
 
     <div class="tiny-10 columns">
-      <h2>Source Tarballs</h2>
-      <p>Link: <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/retroshare_0.6.0.RC2~8551_src.tgz/download">RetroShare-0.6.0-rc2.tar.gz</a></p>
-      <p>Hash Sums</p>
-      <p>Link: <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/checksums.txt.asc/download">checksums.txt.asc</a></p>
+      <h2 id="source"><a href="#source">Source Tarballs</a></h2>
+      <p>Link: <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/retroshare_0.6.0.RC2~8551_src.tgz/download">RetroShare-0.6.0-rc2.tar.gz</a> <a href="http://sourceforge.net/projects/retroshare/files/RetroShare/0.6.0-rc2/checksums.txt.asc/download">checksums</a></p>
+      
+      <p>Development Snapshots from Git: <a href="https://github.com/RetroShare/RetroShare/archive/master.tar.gz">.tar.gz</a> <a href="https://github.com/RetroShare/RetroShare/archive/master.zip">.zip</a></p>
+            
     </div>
   </div>
 


### PR DESCRIPTION
changes available here: https://cavebeat.github.io/retroshare.github.io/downloads.html#source