### PR TITLE
Remove the number of Mageia version in download link

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -304,7 +304,7 @@
         <div class="columns">
           <p>Retroshare is currently available on Mageia.</p>
 
-          <p>Link: <a href="http://mageia.madb.org/package/show/name/retroshare/">Mageia 4</a></p>
+          <p>Link: <a href="http://mageia.madb.org/package/show/name/retroshare/">Mageia</a></p>
 
         </div>
       </div>


### PR DESCRIPTION
The link to Mageia App Database points to the most recent version of Mageia. There is no need to put each Mageia release number for each download link.