### PR TITLE
updated wiki location to https://github.com/RetroShare/documentation/…

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -22,7 +22,7 @@
     <nav>
       <ul>
         <li>
-          <a href="http://retroshare.sourceforge.net/wiki/index.php/">Wiki</a>
+          <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
         </li>
 
         <li>
@@ -355,7 +355,7 @@
           </li>
 
           <li>
-            <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+            <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
           </li>
           
           <li>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <nav>
       <ul>
         <li>
-          <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+          <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
         </li>
 
         <li>
@@ -245,7 +245,7 @@
           </li>
 
           <li>
-            <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+            <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
           </li>
           
          <li>

--- a/screenshots.html
+++ b/screenshots.html
@@ -22,7 +22,7 @@
     <nav>
       <ul>
         <li>
-          <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+          <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
         </li>
 
         <li>
@@ -104,7 +104,7 @@
           </li>
 
           <li>
-            <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+            <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
           </li>
           
           <li>

--- a/support.html
+++ b/support.html
@@ -22,7 +22,7 @@
     <nav>
       <ul>
         <li>
-          <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+          <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
         </li>
 
         <li>
@@ -304,7 +304,7 @@
           </li>
 
           <li>
-            <a href="https://github.com/RetroShare/RetroShare/wiki">Wiki</a>
+            <a href="https://github.com/RetroShare/documentation/wiki">Wiki</a>
           </li>
           
           <li>


### PR DESCRIPTION
…wiki
commit reflects the wiki move from 
https://github.com/RetroShare/RetroShare --> moved --> to --> https://github.com/RetroShare/documentation/wiki