### PR TITLE
update link to mageia package

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -308,7 +308,7 @@
         <div class="columns">
           <p>Retroshare is currently available on Mageia.</p>
 
-          <p>Link: <a href="http://mageia.madb.org/package/show/name/retroshare/">Mageia</a></p>
+          <p>Link: <a href="http://madb.mageia.org/package/show/name/retroshare/release/cauldron">Mageia</a></p>
 
         </div>
       </div>


### PR DESCRIPTION
RS 0.6 is only available for Mageia [Cauldron](https://wiki.mageia.org/en/Cauldron).