### PR TITLE
Add install step for debian users: add repo key

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -135,6 +135,7 @@
         # for Retroshare nightly builds<br>
         &nbsp;&nbsp;&nbsp;<strong>sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/AsamK:/RetroShare/Debian_8.0/ /' >> /etc/apt/sources.list.d/retroshare06-git.list" </strong><br>
         # then<br>
+        &nbsp;&nbsp;&nbsp;<strong>wget -qO - http://download.opensuse.org/repositories/home:AsamK:RetroShare/Debian_8.0/Release.key | sudo apt-key add -</strong><br>
         &nbsp;&nbsp;&nbsp;<strong>sudo apt-get update</strong><br>
         &nbsp;&nbsp;&nbsp;<strong>sudo apt-get install retroshare06</strong><br>
       </blockquote>


### PR DESCRIPTION
Without this step, apt will complain about untrusted packages.
Instructions from [here](http://retroshare.sourceforge.net/forum/viewtopic.php?f=8&t=4279#p13086).
Extra "-" added to what Svampen said in that post; this makes wget properly redirect the key to stdout.